### PR TITLE
Support ruby 2.7

### DIFF
--- a/lib/time_will_tell.rb
+++ b/lib/time_will_tell.rb
@@ -1,2 +1,3 @@
+require 'date'
 require 'time_will_tell/version'
 require 'time_will_tell/railtie' if defined?(Rails)

--- a/lib/time_will_tell/helpers/date_range_helper.rb
+++ b/lib/time_will_tell/helpers/date_range_helper.rb
@@ -40,7 +40,7 @@ module TimeWillTell
           end
         end
 
-        without_year = I18n.t("#{scope}.#{template}", dates)
+        without_year = I18n.t("#{scope}.#{template}", **dates)
 
         if show_year && from_date.year == to_date.year
           I18n.t("#{scope}.with_year", date_range: without_year, year: from_year, default: without_year)

--- a/lib/time_will_tell/railtie.rb
+++ b/lib/time_will_tell/railtie.rb
@@ -1,4 +1,5 @@
 require 'rails/railtie'
+require 'active_support/all'
 require 'time_will_tell/helpers/date_helper'
 require 'time_will_tell/helpers/date_range_helper'
 


### PR DESCRIPTION
Fix deprecation warning:

```
lib/time_will_tell/helpers/date_range_helper.rb:43: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```